### PR TITLE
feat: support custom base URL for Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ cd zen-mcp-server
       "env": {
         "PATH": "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:~/.local/bin",
         "GEMINI_API_KEY": "your-key-here",
+        "GEMINI_BASE_URL": "https://your-custom-endpoint.com",
         "DISABLED_TOOLS": "analyze,refactor,testgen,secaudit,docgen,tracer",
         "DEFAULT_MODEL": "auto"
       }
@@ -121,6 +122,8 @@ cd zen-mcp-server
   }
 }
 ```
+
+`GEMINI_BASE_URL` is optional and defaults to `https://generativelanguage.googleapis.com`.
 
 **3. Start Using!**
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ This guide covers all configuration options for the Zen MCP Server. The server i
 # Basic configuration
 DEFAULT_MODEL=auto
 GEMINI_API_KEY=your-gemini-key
+GEMINI_BASE_URL=https://your-custom-endpoint.com  # optional, defaults to https://generativelanguage.googleapis.com
 OPENAI_API_KEY=your-openai-key
 ```
 
@@ -29,8 +30,10 @@ OPENAI_API_KEY=your-openai-key
 # Google Gemini API
 GEMINI_API_KEY=your_gemini_api_key_here
 # Get from: https://makersuite.google.com/app/apikey
+# Optional: custom endpoint (proxy, Vertex AI, etc.)
+GEMINI_BASE_URL=https://your-custom-endpoint.com  # defaults to https://generativelanguage.googleapis.com
 
-# OpenAI API  
+# OpenAI API
 OPENAI_API_KEY=your_openai_api_key_here
 # Get from: https://platform.openai.com/api-keys
 

--- a/server.py
+++ b/server.py
@@ -379,7 +379,14 @@ def configure_providers():
     """
     # Log environment variable status for debugging
     logger.debug("Checking environment variables for API keys...")
-    api_keys_to_check = ["OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY", "XAI_API_KEY", "CUSTOM_API_URL"]
+    api_keys_to_check = [
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "GEMINI_API_KEY",
+        "GEMINI_BASE_URL",
+        "XAI_API_KEY",
+        "CUSTOM_API_URL",
+    ]
     for key in api_keys_to_check:
         value = os.getenv(key)
         logger.debug(f"  {key}: {'[PRESENT]' if value else '[MISSING]'}")

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,0 +1,36 @@
+import os
+from unittest.mock import patch
+
+from providers.base import ProviderType
+from providers.gemini import GeminiModelProvider
+
+
+class TestGeminiProvider:
+    """Test Gemini provider initialization and configuration."""
+
+    def setup_method(self):
+        import utils.model_restrictions
+
+        utils.model_restrictions._restriction_service = None
+
+    def teardown_method(self):
+        import utils.model_restrictions
+
+        utils.model_restrictions._restriction_service = None
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_initialization_default(self):
+        provider = GeminiModelProvider("test-key")
+        assert provider.api_key == "test-key"
+        assert provider.get_provider_type() == ProviderType.GOOGLE
+        assert provider.base_url == GeminiModelProvider.DEFAULT_BASE_URL
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_initialization_with_custom_url(self):
+        provider = GeminiModelProvider("test-key", base_url="https://custom.example.com")
+        assert provider.base_url == "https://custom.example.com"
+
+    @patch.dict(os.environ, {"GEMINI_BASE_URL": "https://env.example.com"}, clear=True)
+    def test_env_base_url(self):
+        provider = GeminiModelProvider("test-key")
+        assert provider.base_url == "https://env.example.com"


### PR DESCRIPTION
## Summary
- allow Gemini provider to use a custom base URL via `GEMINI_BASE_URL` or constructor argument
- default Gemini endpoint to `https://generativelanguage.googleapis.com`
- document optional base URL and add tests

## Testing
- `ruff check providers/gemini.py tests/test_gemini_provider.py`
- `black providers/gemini.py tests/test_gemini_provider.py`
- `isort providers/gemini.py tests/test_gemini_provider.py`
- `pytest tests/test_gemini_provider.py tests/test_gemini_token_usage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c65aa279908320bedfae2513b8f66a